### PR TITLE
Migrate Server commands to FlowCord v2 commands

### DIFF
--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/discovery/discovery.embeds.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/discovery/discovery.embeds.ts
@@ -1,20 +1,21 @@
-import { EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, type ChatInputCommandInteraction } from 'discord.js';
 
-import type { AdminMenu } from '@bot/classes';
+import type { AdminMenuContext } from '@bot/classes';
 
 const getDiscoveryMenuEmbeds = async (
-  menu: AdminMenu,
+  ctx: AdminMenuContext,
   defaultPrompt = 'Please enter a new server description to be displayed on the server discovery page.'
 ) => {
-  const prompt = menu.prompt || defaultPrompt;
-  const server = await menu.getServer();
+  const prompt = (ctx.state.get('prompt') as string) || defaultPrompt;
+  const server = await ctx.admin.getServer();
+  const interaction = ctx.interaction as ChatInputCommandInteraction;
 
   return [
     new EmbedBuilder()
       .setColor('Gold')
       .setAuthor({
         name: `${server.name} Discovery Settings`,
-        iconURL: menu.interaction?.guild?.iconURL() ?? undefined,
+        iconURL: interaction.guild?.iconURL() ?? undefined,
       })
       .setDescription(`${prompt ? '' + prompt + '\n\n' : ''}`)
       .addFields(

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/discovery/discovery.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/discovery/discovery.ts
@@ -5,10 +5,10 @@ import {
 } from 'discord.js';
 
 import { saveServer } from '@bot/cache';
-import { AdminMenu, AdminMenuBuilder, MenuButtonConfig } from '@bot/classes';
-import { MenuWorkflow } from '@flowcord';
+import { AdminMenuBuilderV2, type AdminMenuContext } from '@bot/classes';
 import type { ISlashCommand } from '@bot/structures/interfaces';
 import { onlyAdminRoles } from '@bot/utils';
+import type { ButtonInputConfig } from '@flowcord/v2';
 
 import getDiscoveryMenuEmbeds from './discovery.embeds';
 import { DISCOVERY_DESCRIPTION_COMMAND_NAME } from './discoveryDescription';
@@ -16,7 +16,7 @@ import { DISCOVERY_DESCRIPTION_COMMAND_NAME } from './discoveryDescription';
 const COMMAND_NAME = 'discovery';
 export const DISCOVERY_COMMAND_NAME = COMMAND_NAME;
 
-export const DiscoveryCommand: ISlashCommand<AdminMenu> = {
+export const DiscoveryCommand: ISlashCommand = {
   name: COMMAND_NAME,
   anyUserPermissions: ['Administrator'],
   onlyRoles: onlyAdminRoles,
@@ -26,8 +26,8 @@ export const DiscoveryCommand: ISlashCommand<AdminMenu> = {
     .setName(COMMAND_NAME)
     .setDescription('Update your server discovery settings')
     .setContexts(InteractionContextType.Guild),
-  createMenu: async (session): Promise<AdminMenu> =>
-    new AdminMenuBuilder(session, COMMAND_NAME)
+  createMenuV2: (session) =>
+    new AdminMenuBuilderV2(session, COMMAND_NAME)
       .setButtons(getDiscoveryButtons)
       .setEmbeds(getDiscoveryMenuEmbeds)
       .setCancellable()
@@ -37,9 +37,9 @@ export const DiscoveryCommand: ISlashCommand<AdminMenu> = {
 };
 
 async function getDiscoveryButtons(
-  menu: AdminMenu
-): Promise<MenuButtonConfig<AdminMenu>[]> {
-  const server = await menu.getServer();
+  ctx: AdminMenuContext
+): Promise<ButtonInputConfig<AdminMenuContext>[]> {
+  const server = await ctx.admin.getServer();
 
   return [
     {
@@ -48,18 +48,17 @@ async function getDiscoveryButtons(
       style: server.discovery.enabled
         ? ButtonStyle.Danger
         : ButtonStyle.Success,
-      onClick: async (menu) => {
-        const server = await menu.getServer();
+      action: async (ctx: AdminMenuContext) => {
+        const server = await ctx.admin.getServer();
         server.discovery.enabled = !server.discovery.enabled;
         await saveServer(server);
-        await menu.refresh();
       },
     },
     {
       label: 'Set Description',
       style: ButtonStyle.Primary,
-      onClick: async (menu) =>
-        MenuWorkflow.openMenu(menu, DISCOVERY_DESCRIPTION_COMMAND_NAME),
+      action: async (ctx: AdminMenuContext) =>
+        ctx.goTo(DISCOVERY_DESCRIPTION_COMMAND_NAME),
     },
   ];
 }

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/discovery/discoveryDescription.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/discovery/discoveryDescription.ts
@@ -1,8 +1,7 @@
 import { InteractionContextType, SlashCommandBuilder } from 'discord.js';
 
 import { saveServer } from '@bot/cache';
-import { AdminMenu, AdminMenuBuilder } from '@bot/classes';
-import { MenuWorkflow } from '@flowcord';
+import { AdminMenuBuilderV2, type AdminMenuContext } from '@bot/classes';
 import type { ISlashCommand } from '@bot/structures/interfaces';
 import { onlyAdminRoles } from '@bot/utils';
 
@@ -12,7 +11,7 @@ import getDiscoveryMenuEmbeds from './discovery.embeds';
 const COMMAND_NAME = 'discovery-description';
 export const DISCOVERY_DESCRIPTION_COMMAND_NAME = COMMAND_NAME;
 
-export const DiscoveryDescriptionCommand: ISlashCommand<AdminMenu> = {
+export const DiscoveryDescriptionCommand: ISlashCommand = {
   name: COMMAND_NAME,
   anyUserPermissions: ['Administrator'],
   onlyRoles: onlyAdminRoles,
@@ -22,18 +21,17 @@ export const DiscoveryDescriptionCommand: ISlashCommand<AdminMenu> = {
     .setName(COMMAND_NAME)
     .setDescription('Update your server discovery description')
     .setContexts(InteractionContextType.Guild),
-  createMenu: async (session): Promise<AdminMenu> =>
-    new AdminMenuBuilder(session, COMMAND_NAME)
+  createMenuV2: (session) =>
+    new AdminMenuBuilderV2(session, COMMAND_NAME)
       .setEmbeds(getDiscoveryMenuEmbeds)
-      .setMessageHandler(async (menu: AdminMenu, response: string) => {
-        const server = await menu.getServer();
+      .setMessageHandler(async (ctx: AdminMenuContext, response: string) => {
+        const server = await ctx.admin.getServer();
         server.discovery.description = response;
 
         await saveServer(server);
-        await menu.session.goBack(async () =>
-          MenuWorkflow.openMenu(menu, DISCOVERY_COMMAND_NAME)
-        );
-        menu.prompt = `Successfully updated the server description.`;
+        ctx.state.set('prompt', 'Successfully updated the server description.');
+        await ctx.goBack();
       })
+      .setFallbackMenu(DISCOVERY_COMMAND_NAME)
       .build(),
 };

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/server.embeds.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/server.embeds.ts
@@ -1,26 +1,25 @@
-import { EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, type ChatInputCommandInteraction } from 'discord.js';
 
-import type { AdminMenu, MenuCommandOptions } from '@bot/classes';
+import type { AdminMenuContext } from '@bot/classes';
 
-export const getServerMenuEmbeds = async <
-  C extends MenuCommandOptions = MenuCommandOptions
->(
-  menu: AdminMenu<C>,
+export const getServerMenuEmbeds = async (
+  ctx: AdminMenuContext,
   defaultPrompt = 'Please select an option to manage your server settings.'
 ) => {
-  const server = await menu.getServer();
-  const prompt = menu.prompt || defaultPrompt;
+  const server = await ctx.admin.getServer();
+  const prompt = (ctx.state.get('prompt') as string) || defaultPrompt;
+  const interaction = ctx.interaction as ChatInputCommandInteraction;
 
   const prefixes: string =
     server.prefixes && server.prefixes.length > 0
       ? server.prefixes.map((prefix) => `\`${prefix}\``).join(', ')
       : '`.` (default)';
 
-  const adminRoles = await menu.getRoles('admin');
+  const adminRoles = await ctx.admin.getRoles('admin');
   const adminRolesList: string = adminRoles.length
     ? adminRoles.join(', ')
     : 'None';
-  const modRoles = await menu.getRoles('mod');
+  const modRoles = await ctx.admin.getRoles('mod');
   const modRolesList: string = modRoles.length ? modRoles.join(', ') : 'None';
 
   return [
@@ -28,7 +27,7 @@ export const getServerMenuEmbeds = async <
       .setColor('Gold')
       .setAuthor({
         name: `${server.name} Server Options`,
-        iconURL: menu.interaction.guild?.iconURL() || undefined,
+        iconURL: interaction.guild?.iconURL() || undefined,
       })
       .setDescription(
         `${prompt ? '**' + prompt + '**\n\n' : ''}` +

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/server.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/server.ts
@@ -4,10 +4,10 @@ import {
   SlashCommandBuilder,
 } from 'discord.js';
 
-import { AdminMenu, AdminMenuBuilder, MenuButtonConfig } from '@bot/classes';
-import { MenuWorkflow } from '@flowcord';
+import { AdminMenuBuilderV2, type AdminMenuContext } from '@bot/classes';
 import type { ISlashCommand } from '@bot/structures/interfaces';
 import { onlyAdminRoles } from '@bot/utils';
+import type { ButtonInputConfig } from '@flowcord/v2';
 
 import { DISCOVERY_COMMAND_NAME } from '../discovery/discovery';
 import { getServerMenuEmbeds } from './server.embeds';
@@ -17,7 +17,7 @@ import { SERVER_MANAGE_ROLES_COMMAND_NAME } from './serverManageRoles';
 const COMMAND_NAME = 'server';
 export const SERVER_COMMAND_NAME = COMMAND_NAME;
 
-export const ServerCommand: ISlashCommand<AdminMenu> = {
+export const ServerCommand: ISlashCommand = {
   name: COMMAND_NAME,
   anyUserPermissions: ['Administrator'],
   onlyRoles: onlyAdminRoles,
@@ -27,8 +27,8 @@ export const ServerCommand: ISlashCommand<AdminMenu> = {
     .setName(COMMAND_NAME)
     .setDescription('Update your PokeSandbox server settings')
     .setContexts(InteractionContextType.Guild),
-  createMenu: async (session): Promise<AdminMenu> =>
-    new AdminMenuBuilder(session, COMMAND_NAME)
+  createMenuV2: (session) =>
+    new AdminMenuBuilderV2(session, COMMAND_NAME)
       .setButtons(getServerButtons)
       .setEmbeds(getServerMenuEmbeds)
       .setCancellable()
@@ -36,7 +36,9 @@ export const ServerCommand: ISlashCommand<AdminMenu> = {
       .build(),
 };
 
-const getServerButtons = async (): Promise<MenuButtonConfig[]> => {
+const getServerButtons = async (): Promise<
+  ButtonInputConfig<AdminMenuContext>[]
+> => {
   const subMenuButtons: { id: string; command: string; option?: string }[] = [
     { id: 'Prefix', command: SERVER_MANAGE_PREFIXES_COMMAND_NAME },
     {
@@ -56,7 +58,7 @@ const getServerButtons = async (): Promise<MenuButtonConfig[]> => {
     label: (idx + 1).toString(),
     id,
     style: ButtonStyle.Primary,
-    onClick: async (menu) =>
-      MenuWorkflow.openMenu(menu, command, { role_type: option }),
+    action: async (ctx: AdminMenuContext) =>
+      ctx.goTo(command, { role_type: option }),
   }));
 };

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverAddPrefix.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverAddPrefix.ts
@@ -1,17 +1,17 @@
 import { InteractionContextType, SlashCommandBuilder } from 'discord.js';
 
 import { saveServer } from '@bot/cache';
-import { AdminMenuBuilder, type AdminMenu } from '@bot/classes';
-import { MenuWorkflow } from '@flowcord';
-import { ISlashCommand } from '@bot/structures/interfaces';
+import { AdminMenuBuilderV2, type AdminMenuContext } from '@bot/classes';
+import type { ISlashCommand } from '@bot/structures/interfaces';
 import { onlyAdminRoles } from '@bot/utils';
 
 import { getServerMenuEmbeds } from './server.embeds';
+import { SERVER_MANAGE_PREFIXES_COMMAND_NAME } from './serverManagePrefixes';
 
 const COMMAND_NAME = 'server-add-prefix';
 export const SERVER_ADD_PREFIX_COMMAND_NAME = COMMAND_NAME;
 
-export const ServerAddPrefixCommand: ISlashCommand<AdminMenu> = {
+export const ServerAddPrefixCommand: ISlashCommand = {
   name: COMMAND_NAME,
   anyUserPermissions: ['Administrator'],
   onlyRoles: onlyAdminRoles,
@@ -21,32 +21,32 @@ export const ServerAddPrefixCommand: ISlashCommand<AdminMenu> = {
     .setName(COMMAND_NAME)
     .setDescription('Add a new command prefix to your server')
     .setContexts(InteractionContextType.Guild),
-  createMenu: async (session): Promise<AdminMenu> =>
-    new AdminMenuBuilder(session, COMMAND_NAME)
-      .setEmbeds((menu) =>
+  createMenuV2: (session) =>
+    new AdminMenuBuilderV2(session, COMMAND_NAME)
+      .setEmbeds((ctx) =>
         getServerMenuEmbeds(
-          menu,
+          ctx,
           'Please enter a new prefix to use with this bot on your server.'
         )
       )
-      .setMessageHandler(async (menu, response) => {
-        const server = await menu.getServer();
+      .setMessageHandler(async (ctx: AdminMenuContext, response: string) => {
+        const server = await ctx.admin.getServer();
 
-        try {
-          if (!server.prefixes.includes(response)) {
-            server.prefixes = [...server.prefixes, response];
-            await saveServer(server);
-            menu.prompt = `Successfully added the prefix: \`${response}\``;
-          } else {
-            menu.prompt =
-              'Oops! The entered prefix already exists for this server.';
-          }
-        } catch (error) {
-          await menu.session.handleError(error);
+        if (!server.prefixes.includes(response)) {
+          server.prefixes = [...server.prefixes, response];
+          await saveServer(server);
+          ctx.state.set(
+            'prompt',
+            `Successfully added the prefix: \`${response}\``
+          );
+        } else {
+          ctx.state.set(
+            'prompt',
+            'Oops! The entered prefix already exists for this server.'
+          );
         }
-        await menu.session.goBack(() =>
-          MenuWorkflow.openMenu(menu, SERVER_ADD_PREFIX_COMMAND_NAME)
-        );
+        await ctx.goBack();
       })
+      .setFallbackMenu(SERVER_MANAGE_PREFIXES_COMMAND_NAME)
       .build(),
 };

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverAddRole.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverAddRole.ts
@@ -5,14 +5,10 @@ import {
 } from 'discord.js';
 
 import { saveServer } from '@bot/cache';
-import {
-  AdminMenuBuilder,
-  SelectMenuConfig,
-  type AdminMenu,
-} from '@bot/classes';
-import { MenuWorkflow } from '@flowcord';
-import { ISlashCommand } from '@bot/structures/interfaces';
-import { assertOptions, onlyAdminRoles } from '@bot/utils';
+import { AdminMenuBuilderV2, type AdminMenuContext } from '@bot/classes';
+import type { ISlashCommand } from '@bot/structures/interfaces';
+import { onlyAdminRoles } from '@bot/utils';
+import type { SelectInputConfig } from '@flowcord/v2';
 
 import { getServerMenuEmbeds } from './server.embeds';
 import { SERVER_MANAGE_ROLES_COMMAND_NAME } from './serverManageRoles';
@@ -23,12 +19,8 @@ export const SERVER_ADD_ROLE_COMMAND_NAME = COMMAND_NAME;
 type ServerAddRoleCommandOptions = {
   role_type: string;
 };
-type ServerAddRoleCommand = ISlashCommand<
-  AdminMenu<ServerAddRoleCommandOptions>,
-  ServerAddRoleCommandOptions
->;
 
-export const ServerAddRoleCommand: ServerAddRoleCommand = {
+export const ServerAddRoleCommand: ISlashCommand = {
   name: COMMAND_NAME,
   anyUserPermissions: ['Administrator'],
   onlyRoles: onlyAdminRoles,
@@ -48,37 +40,37 @@ export const ServerAddRoleCommand: ServerAddRoleCommand = {
           { name: 'Mod', value: 'mod' }
         )
     ),
-  createMenu: async (session, options) => {
-    assertOptions(options);
-    const { role_type } = options;
+  createMenuV2: (session, options) => {
+    const { role_type } = options as unknown as ServerAddRoleCommandOptions;
+    if (!role_type) {
+      throw new Error('Role type is required to add a server role.');
+    }
 
-    return new AdminMenuBuilder(session, COMMAND_NAME, options)
-      .setEmbeds((menu) =>
+    return new AdminMenuBuilderV2(session, COMMAND_NAME, options)
+      .setEmbeds((ctx) =>
         getServerMenuEmbeds(
-          menu,
+          ctx,
           `Please select a role to grant Bot ${role_type} privileges to.`
         )
       )
-      .setSelectMenu(async (menu) =>
-        getServerAddRoleSelectMenu(menu, role_type)
-      )
+      .setSelectMenu((ctx) => getServerAddRoleSelectMenu(ctx, role_type))
+      .setFallbackMenu(SERVER_MANAGE_ROLES_COMMAND_NAME, {
+        role_type,
+      })
       .build();
   },
 };
 
 export const getServerAddRoleSelectMenu = async (
-  _menu: AdminMenu<ServerAddRoleCommandOptions>,
+  _ctx: AdminMenuContext,
   roleType: string
-): Promise<SelectMenuConfig<AdminMenu<ServerAddRoleCommandOptions>>> => {
+): Promise<SelectInputConfig<AdminMenuContext>> => {
   return {
     builder: new RoleSelectMenuBuilder()
       .setCustomId(`server-add-${roleType}-role`)
       .setPlaceholder('Select a role to add'),
-    onSelect: async (
-      menu: AdminMenu<ServerAddRoleCommandOptions>,
-      selectedRoleIds: string[]
-    ) => {
-      const server = await menu.getServer();
+    onSelect: async (ctx: AdminMenuContext, selectedRoleIds: string[]) => {
+      const server = await ctx.admin.getServer();
       const roleIds =
         roleType === 'admin' ? server.adminRoleIds : server.modRoleIds;
       const newRoleIds = selectedRoleIds.filter(
@@ -86,32 +78,25 @@ export const getServerAddRoleSelectMenu = async (
       );
 
       if (newRoleIds.length > 0) {
-        try {
-          const newRoles = await Promise.all(
-            newRoleIds.map((roleId) => menu.getGuildRole(roleId))
-          );
+        const newRoles = await Promise.all(
+          newRoleIds.map((roleId) => ctx.admin.getGuildRole(roleId))
+        );
 
-          if (roleType === 'admin') {
-            server.adminRoleIds = roleIds.concat(newRoleIds);
-          } else if (roleType === 'mod') {
-            server.modRoleIds = roleIds.concat(newRoleIds);
-          }
-
-          await saveServer(server);
-          menu.prompt = `Successfully added the ${roleType} roles: ${newRoles.join(
-            ', '
-          )}`;
-        } catch (error) {
-          await menu.session.handleError(error);
+        if (roleType === 'admin') {
+          server.adminRoleIds = roleIds.concat(newRoleIds);
+        } else if (roleType === 'mod') {
+          server.modRoleIds = roleIds.concat(newRoleIds);
         }
+
+        await saveServer(server);
+        ctx.state.set(
+          'prompt',
+          `Successfully added the ${roleType} roles: ${newRoles.join(', ')}`
+        );
       } else {
-        menu.prompt = `No new ${roleType} roles were selected.`;
+        ctx.state.set('prompt', `No new ${roleType} roles were selected.`);
       }
-      await menu.session.goBack(() =>
-        MenuWorkflow.openMenu(menu, SERVER_MANAGE_ROLES_COMMAND_NAME, {
-          role_type: roleType,
-        })
-      );
+      await ctx.goBack();
     },
   };
 };

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverManagePrefixes.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverManagePrefixes.ts
@@ -5,14 +5,10 @@ import {
 } from 'discord.js';
 
 import { saveServer } from '@bot/cache';
-import {
-  AdminMenuBuilder,
-  MenuButtonConfig,
-  type AdminMenu,
-} from '@bot/classes';
-import { MenuWorkflow } from '@flowcord';
-import { ISlashCommand } from '@bot/structures/interfaces';
+import { AdminMenuBuilderV2, type AdminMenuContext } from '@bot/classes';
+import type { ISlashCommand } from '@bot/structures/interfaces';
 import { onlyAdminRoles } from '@bot/utils';
+import type { ButtonInputConfig } from '@flowcord/v2';
 
 import { getServerMenuEmbeds } from './server.embeds';
 import { SERVER_ADD_PREFIX_COMMAND_NAME } from './serverAddPrefix';
@@ -20,7 +16,7 @@ import { SERVER_ADD_PREFIX_COMMAND_NAME } from './serverAddPrefix';
 const COMMAND_NAME = 'server-manage-prefixes';
 export const SERVER_MANAGE_PREFIXES_COMMAND_NAME = COMMAND_NAME;
 
-export const ServerManagePrefixesCommand: ISlashCommand<AdminMenu> = {
+export const ServerManagePrefixesCommand: ISlashCommand = {
   name: COMMAND_NAME,
   anyUserPermissions: ['Administrator'],
   onlyRoles: onlyAdminRoles,
@@ -30,12 +26,10 @@ export const ServerManagePrefixesCommand: ISlashCommand<AdminMenu> = {
     .setName(COMMAND_NAME)
     .setDescription('Manage command prefixes for your server')
     .setContexts(InteractionContextType.Guild),
-  createMenu: async (session): Promise<AdminMenu> =>
-    new AdminMenuBuilder(session, COMMAND_NAME)
+  createMenuV2: (session) =>
+    new AdminMenuBuilderV2(session, COMMAND_NAME)
       .setButtons(getServerManagePrefixesButtons)
-      .setEmbeds((menu: AdminMenu) =>
-        getServerMenuEmbeds(menu, 'Add or remove a prefix.')
-      )
+      .setEmbeds((ctx) => getServerMenuEmbeds(ctx, 'Add or remove a prefix.'))
       .setCancellable()
       .setReturnable()
       .setTrackedInHistory()
@@ -43,39 +37,32 @@ export const ServerManagePrefixesCommand: ISlashCommand<AdminMenu> = {
 };
 
 export const getServerManagePrefixesButtons = async (
-  menu: AdminMenu
-): Promise<MenuButtonConfig<AdminMenu>[]> => {
-  const server = await menu.getServer();
+  ctx: AdminMenuContext
+): Promise<ButtonInputConfig<AdminMenuContext>[]> => {
+  const server = await ctx.admin.getServer();
 
   return [
     {
       label: 'Add Prefix',
       style: ButtonStyle.Success,
       fixedPosition: 'start',
-      onClick: async (menu) =>
-        MenuWorkflow.openMenu(menu, SERVER_ADD_PREFIX_COMMAND_NAME),
+      action: async (ctx: AdminMenuContext) =>
+        ctx.goTo(SERVER_ADD_PREFIX_COMMAND_NAME),
     },
     ...server.prefixes.map((prefix, idx) => ({
       label: `Remove ${prefix}`,
       style: ButtonStyle.Danger,
-      onClick: (menu: AdminMenu) => handleRemovePrefixButtonClick(menu, idx),
+      action: async (ctx: AdminMenuContext) => {
+        const server = await ctx.admin.getServer();
+
+        const removedPrefix = server.prefixes?.splice(idx, 1)[0];
+        await saveServer(server);
+        ctx.state.set(
+          'prompt',
+          `Successfully removed the prefix: \`${removedPrefix}\``
+        );
+      },
       id: idx.toString(),
     })),
   ];
-};
-
-export const handleRemovePrefixButtonClick = async (
-  menu: AdminMenu,
-  idx: number
-) => {
-  const server = await menu.getServer();
-
-  try {
-    const removedPrefix = server.prefixes?.splice(idx, 1)[0];
-    await saveServer(server);
-    menu.prompt = `Successfully removed the prefix: \`${removedPrefix}\``;
-  } catch (error) {
-    await menu.session.handleError(error);
-  }
-  await menu.refresh();
 };

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverManageRoles.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/serverManagement/server/serverManageRoles.ts
@@ -5,28 +5,19 @@ import {
 } from 'discord.js';
 
 import { saveServer } from '@bot/cache';
-import {
-  AdminMenuBuilder,
-  MenuButtonConfig,
-  type AdminMenu,
-} from '@bot/classes';
-import { MenuWorkflow } from '@flowcord';
-import { ISlashCommand } from '@bot/structures/interfaces';
+import { AdminMenuBuilderV2, type AdminMenuContext } from '@bot/classes';
+import type { ISlashCommand } from '@bot/structures/interfaces';
 import { onlyAdminRoles } from '@bot/utils';
+import type { ButtonInputConfig } from '@flowcord/v2';
 
 import { getServerMenuEmbeds } from './server.embeds';
 import { SERVER_ADD_ROLE_COMMAND_NAME } from './serverAddRole';
-import { ServerManageRolesCommandOptions } from './types';
+import type { ServerManageRolesCommandOptions } from './types';
 
 const COMMAND_NAME = 'server-manage-roles';
 export const SERVER_MANAGE_ROLES_COMMAND_NAME = COMMAND_NAME;
 
-type ServerManageRolesCommand = ISlashCommand<
-  AdminMenu<ServerManageRolesCommandOptions>,
-  ServerManageRolesCommandOptions
->;
-
-export const ServerManageRolesCommand: ServerManageRolesCommand = {
+export const ServerManageRolesCommand: ISlashCommand = {
   name: COMMAND_NAME,
   anyUserPermissions: ['Administrator'],
   onlyRoles: onlyAdminRoles,
@@ -46,17 +37,17 @@ export const ServerManageRolesCommand: ServerManageRolesCommand = {
           { name: 'Mod', value: 'mod' }
         )
     ),
-  createMenu: async (session, options) => {
-    if (!options?.role_type) {
+  createMenuV2: (session, options) => {
+    const { role_type } = options as unknown as ServerManageRolesCommandOptions;
+    if (!role_type) {
       throw new Error('Role type is required to manage server roles.');
     }
 
-    const { role_type } = options;
-    return new AdminMenuBuilder(session, COMMAND_NAME, options)
-      .setButtons((menu) => getServerManageRolesButtons(menu, role_type))
-      .setEmbeds((menu) =>
+    return new AdminMenuBuilderV2(session, COMMAND_NAME, options)
+      .setButtons((ctx) => getServerManageRolesButtons(ctx, role_type), {})
+      .setEmbeds((ctx) =>
         getServerMenuEmbeds(
-          menu,
+          ctx,
           `Add or Remove a Role with Bot ${role_type} privileges.`
         )
       )
@@ -68,26 +59,26 @@ export const ServerManageRolesCommand: ServerManageRolesCommand = {
 };
 
 export const getServerManageRolesButtons = async (
-  menu: AdminMenu<ServerManageRolesCommandOptions>,
+  ctx: AdminMenuContext,
   roleType: string
-): Promise<MenuButtonConfig<AdminMenu<ServerManageRolesCommandOptions>>[]> => {
-  const roles = await menu.getRoles(roleType);
+): Promise<ButtonInputConfig<AdminMenuContext>[]> => {
+  const roles = await ctx.admin.getRoles(roleType as 'admin' | 'mod');
 
   return [
     {
       label: 'Add Role',
       style: ButtonStyle.Success,
       fixedPosition: 'start',
-      onClick: async (menu) =>
-        MenuWorkflow.openMenu(menu, SERVER_ADD_ROLE_COMMAND_NAME, {
+      action: async (ctx: AdminMenuContext) =>
+        ctx.goTo(SERVER_ADD_ROLE_COMMAND_NAME, {
           role_type: roleType,
         }),
     },
     ...roles.map((role, idx) => ({
       label: `Remove [${typeof role === 'string' ? role : role.name}]`,
       style: ButtonStyle.Danger,
-      onClick: async () => {
-        const server = await menu.getServer();
+      action: async (ctx: AdminMenuContext) => {
+        const server = await ctx.admin.getServer();
 
         if (roleType === 'admin') {
           server.adminRoleIds.splice(idx, 1);
@@ -96,7 +87,6 @@ export const getServerManageRolesButtons = async (
         }
 
         await saveServer(server);
-        await menu.refresh();
       },
       id: idx.toString(),
     })),


### PR DESCRIPTION
- Migrated server command flows to FlowCord v2 menu/session architecture for consistent interaction behavior.
- Removed command-level interaction defer plumbing now that defer behavior is handled by the framework.
- Updated command flows to use typed state/action patterns introduced in v2 generic menu APIs.
- Standardized navigation behavior across server command menus, including fallback return paths.
- Aligned command modal flows with declarative opensModal triggers and centralized modal submission handling.
- Reduced command-specific interaction edge cases by relying on shared renderer/session lifecycle behavior.