### PR TITLE
progression edit modal

### DIFF
--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progression.embeds.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progression.embeds.ts
@@ -117,33 +117,13 @@ export const progressionsMenuEmbeds = async (
 export const progressionEditMenuEmbeds = async (
   ctx: AdminMenuContext<ProgressionEditMenuState>,
   regionId: string,
-  progressionKey: string,
-  editField?: string
+  progressionKey: string
 ) => {
   const region = await ctx.admin.getRegion(regionId);
   const progression = region.progressionDefinitions.get(progressionKey);
   assert(progression, 'Progression definition not found.');
 
-  let prompt = ctx.state.get('prompt');
-  if (editField) {
-    switch (editField) {
-      case 'name':
-        prompt = 'Enter a new name.';
-        break;
-      case 'description':
-        prompt = 'Enter a new description.';
-        break;
-      case 'visibility':
-        prompt = 'Select a new visibility option.';
-        break;
-      case 'min':
-        prompt = 'Enter a new minimum value, or clear the current value';
-        break;
-      case 'max':
-        prompt = 'Enter a new maximum value, or clear the current value';
-        break;
-    }
-  }
+  const prompt = ctx.state.get('prompt');
 
   const fields: EmbedField[] = [
     {

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.modal.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.modal.ts
@@ -1,0 +1,188 @@
+import type { AdminMenuContext } from '@bot/classes';
+import type { ModalConfig } from '@flowcord/core';
+import {
+  CacheType,
+  LabelBuilder,
+  ModalBuilder,
+  ModalSubmitFields,
+  StringSelectMenuBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+} from 'discord.js';
+import { Progression } from './types';
+import {
+  getModalSelectValue,
+  getModalTextValue,
+  setValueOnInputBuilderIfExists,
+} from '@bot/utils';
+import { saveRegion } from '@bot/cache';
+
+export const PROGRESSION_EDIT_MODAL_ID = 'progression-edit-modal';
+
+export const getProgressionEditModal = async (
+  ctx: AdminMenuContext,
+  regionId: string,
+  progressionKey: string
+): Promise<ModalConfig<AdminMenuContext>> => {
+  const region = await ctx.admin.getRegion(regionId);
+  const progression = region.progressionDefinitions.get(progressionKey);
+  return buildProgressionEditModal(progression, regionId, progressionKey);
+};
+
+const buildProgressionEditModal = (
+  progression: Progression | undefined,
+  regionId: string,
+  progressionKey: string
+): ModalConfig<AdminMenuContext> => {
+  const builder = new ModalBuilder()
+    .addLabelComponents(
+      new LabelBuilder()
+        .setLabel('name')
+        .setTextInputComponent(
+          setValueOnInputBuilderIfExists(
+            new TextInputBuilder()
+              .setCustomId('progression-name')
+              .setStyle(TextInputStyle.Short)
+              .setPlaceholder('e.g. Badges')
+              .setRequired(true),
+            progression?.name
+          )
+        ),
+      new LabelBuilder()
+        .setLabel('description')
+        .setTextInputComponent(
+          setValueOnInputBuilderIfExists(
+            new TextInputBuilder()
+              .setCustomId('progression-description')
+              .setStyle(TextInputStyle.Paragraph)
+              .setPlaceholder(
+                'e.g. The badges the player must collect in order to complete the region progression.'
+              )
+              .setRequired(false),
+            progression?.description
+          )
+        ),
+      new LabelBuilder().setLabel('visibility').setStringSelectMenuComponent(
+        new StringSelectMenuBuilder()
+          .setCustomId('progression-visibility')
+          .setPlaceholder('Select visibility')
+          .addOptions([
+            {
+              label: 'Public',
+              value: 'public',
+              default: progression?.visibility === 'public',
+            },
+            {
+              label: 'Discoverable',
+              value: 'discoverable',
+              default: progression?.visibility === 'discoverable',
+            },
+            {
+              label: 'Hidden',
+              value: 'hidden',
+              default: progression?.visibility === 'hidden',
+            },
+          ])
+          .setRequired(false)
+      )
+    )
+    .setCustomId(PROGRESSION_EDIT_MODAL_ID)
+    .setTitle(`Edit Progression`);
+  if (progression?.kind === 'milestone') {
+    builder.addLabelComponents(
+      new LabelBuilder().setLabel('sequential').setStringSelectMenuComponent(
+        new StringSelectMenuBuilder()
+          .setCustomId('progression-sequential')
+          .setPlaceholder('Is the progression sequential?')
+          .addOptions([
+            {
+              label: 'Yes',
+              value: 'yes',
+              default: progression.sequential === true,
+            },
+            {
+              label: 'No',
+              value: 'no',
+              default: progression.sequential === false,
+            },
+          ])
+          .setRequired(false)
+      )
+    );
+  } else if (progression?.kind === 'numeric') {
+    builder.addLabelComponents(
+      new LabelBuilder()
+        .setLabel('min')
+        .setTextInputComponent(
+          setValueOnInputBuilderIfExists(
+            new TextInputBuilder()
+              .setCustomId('progression-min')
+              .setStyle(TextInputStyle.Short)
+              .setPlaceholder('Minimum value for the numeric progression')
+              .setRequired(false),
+            progression.min?.toString()
+          )
+        ),
+      new LabelBuilder()
+        .setLabel('max')
+        .setTextInputComponent(
+          setValueOnInputBuilderIfExists(
+            new TextInputBuilder()
+              .setCustomId('progression-max')
+              .setStyle(TextInputStyle.Short)
+              .setPlaceholder('Maximum value for the numeric progression')
+              .setRequired(false),
+            progression.max?.toString()
+          )
+        )
+    );
+  }
+  return {
+    id: PROGRESSION_EDIT_MODAL_ID,
+    builder,
+    onSubmit: async (ctx, fields) => {
+      const region = await ctx.admin.getRegion(regionId);
+      region.progressionDefinitions.set(
+        progressionKey,
+        getupdatedProgression(progression, fields)
+      );
+      await saveRegion(region);
+      await ctx.hardRefresh();
+    },
+  };
+};
+
+const getupdatedProgression = (
+  progression: Progression | undefined,
+  fields: ModalSubmitFields<CacheType>
+): Progression => {
+  let updatedProgression;
+  if (progression?.kind === 'milestone') {
+    updatedProgression = {
+      name: getModalTextValue(fields.fields, 'progression-name', true),
+      description: getModalTextValue(fields.fields, 'progression-description'),
+      kind: progression.kind,
+      visibility: getModalSelectValue(fields.fields, 'progression-visibility'),
+      sequential:
+        getModalSelectValue(fields.fields, 'progression-sequential') === 'yes',
+      milestones: progression.milestones,
+    } as Progression;
+  } else if (progression?.kind === 'numeric') {
+    updatedProgression = {
+      name: getModalTextValue(fields.fields, 'progression-name', true),
+      description: getModalTextValue(fields.fields, 'progression-description'),
+      kind: progression.kind,
+      visibility: getModalSelectValue(fields.fields, 'progression-visibility'),
+      min: getModalTextValue(fields.fields, 'progression-min'),
+      max: getModalTextValue(fields.fields, 'progression-max'),
+    } as Progression;
+  } else {
+    updatedProgression = {
+      name: getModalTextValue(fields.fields, 'progression-name', true),
+      description: getModalTextValue(fields.fields, 'progression-description'),
+      kind: progression?.kind,
+      visibility: getModalSelectValue(fields.fields, 'progression-visibility'),
+    } as Progression;
+  }
+  return updatedProgression;
+};

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.modal.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.modal.ts
@@ -17,6 +17,7 @@ import {
 import { saveRegion } from '@bot/cache';
 import { progressionDefinitionSchema } from 'shared/src/models/region/progressionDefinition';
 import z from 'zod';
+import { assertProgressionKind } from './utils';
 
 export const PROGRESSION_EDIT_MODAL_ID = 'progression-edit-modal';
 
@@ -35,9 +36,9 @@ export const getProgressionEditModal = async (
     .setTitle(`Edit Progression`);
   addCommonProgressionModalFields(builder, progression);
   if (progression?.kind === 'milestone') {
-    addSequentialModalField(builder, progression);
+    addMilestoneKindModalFields(builder, progression);
   } else if (progression?.kind === 'numeric') {
-    addMinMaxModalFields(builder, progression);
+    addNumericKindModalFields(builder, progression);
   }
 
   return {
@@ -50,7 +51,6 @@ export const getProgressionEditModal = async (
         getUpdatedProgression(progression, fields)
       );
       await saveRegion(region);
-      await ctx.hardRefresh();
     },
   };
 };
@@ -113,10 +113,11 @@ const addCommonProgressionModalFields = (
   );
 };
 
-const addSequentialModalField = (
+const addMilestoneKindModalFields = (
   builder: ModalBuilder,
   progression: Progression | undefined
 ): void => {
+  assertProgressionKind('milestone', progression);
   builder.addLabelComponents(
     new LabelBuilder().setLabel('sequential').setStringSelectMenuComponent(
       new StringSelectMenuBuilder()
@@ -126,16 +127,12 @@ const addSequentialModalField = (
           {
             label: 'Yes',
             value: 'yes',
-            default:
-              progression?.kind === 'milestone' &&
-              progression.sequential === true,
+            default: progression.sequential === true,
           },
           {
             label: 'No',
             value: 'no',
-            default:
-              progression?.kind === 'milestone' &&
-              progression.sequential === false,
+            default: progression.sequential === false,
           },
         ])
         .setRequired(false)
@@ -143,10 +140,11 @@ const addSequentialModalField = (
   );
 };
 
-const addMinMaxModalFields = (
+const addNumericKindModalFields = (
   builder: ModalBuilder,
   progression: Progression | undefined
 ): void => {
+  assertProgressionKind('numeric', progression);
   builder.addLabelComponents(
     new LabelBuilder()
       .setLabel('min')
@@ -157,9 +155,7 @@ const addMinMaxModalFields = (
             .setStyle(TextInputStyle.Short)
             .setPlaceholder('Minimum value for the numeric progression')
             .setRequired(false),
-          progression?.kind === 'numeric'
-            ? progression.min?.toString()
-            : undefined
+          progression.min?.toString()
         )
       ),
     new LabelBuilder()
@@ -171,9 +167,7 @@ const addMinMaxModalFields = (
             .setStyle(TextInputStyle.Short)
             .setPlaceholder('Maximum value for the numeric progression')
             .setRequired(false),
-          progression?.kind === 'numeric'
-            ? progression.max?.toString()
-            : undefined
+          progression.max?.toString()
         )
       )
   );

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.modal.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.modal.ts
@@ -9,15 +9,18 @@ import {
   TextInputBuilder,
   TextInputStyle,
 } from 'discord.js';
-import { Progression } from './types';
 import {
   getModalSelectValue,
   getModalTextValue,
   setValueOnInputBuilderIfExists,
 } from '@bot/utils';
 import { saveRegion } from '@bot/cache';
+import { progressionDefinitionSchema } from 'shared/src/models/region/progressionDefinition';
+import z from 'zod';
 
 export const PROGRESSION_EDIT_MODAL_ID = 'progression-edit-modal';
+
+type Progression = z.infer<typeof progressionDefinitionSchema>;
 
 export const getProgressionEditModal = async (
   ctx: AdminMenuContext,
@@ -26,117 +29,17 @@ export const getProgressionEditModal = async (
 ): Promise<ModalConfig<AdminMenuContext>> => {
   const region = await ctx.admin.getRegion(regionId);
   const progression = region.progressionDefinitions.get(progressionKey);
-  return buildProgressionEditModal(progression, regionId, progressionKey);
-};
 
-const buildProgressionEditModal = (
-  progression: Progression | undefined,
-  regionId: string,
-  progressionKey: string
-): ModalConfig<AdminMenuContext> => {
   const builder = new ModalBuilder()
-    .addLabelComponents(
-      new LabelBuilder()
-        .setLabel('name')
-        .setTextInputComponent(
-          setValueOnInputBuilderIfExists(
-            new TextInputBuilder()
-              .setCustomId('progression-name')
-              .setStyle(TextInputStyle.Short)
-              .setPlaceholder('e.g. Badges')
-              .setRequired(true),
-            progression?.name
-          )
-        ),
-      new LabelBuilder()
-        .setLabel('description')
-        .setTextInputComponent(
-          setValueOnInputBuilderIfExists(
-            new TextInputBuilder()
-              .setCustomId('progression-description')
-              .setStyle(TextInputStyle.Paragraph)
-              .setPlaceholder(
-                'e.g. The badges the player must collect in order to complete the region progression.'
-              )
-              .setRequired(false),
-            progression?.description
-          )
-        ),
-      new LabelBuilder().setLabel('visibility').setStringSelectMenuComponent(
-        new StringSelectMenuBuilder()
-          .setCustomId('progression-visibility')
-          .setPlaceholder('Select visibility')
-          .addOptions([
-            {
-              label: 'Public',
-              value: 'public',
-              default: progression?.visibility === 'public',
-            },
-            {
-              label: 'Discoverable',
-              value: 'discoverable',
-              default: progression?.visibility === 'discoverable',
-            },
-            {
-              label: 'Hidden',
-              value: 'hidden',
-              default: progression?.visibility === 'hidden',
-            },
-          ])
-          .setRequired(false)
-      )
-    )
     .setCustomId(PROGRESSION_EDIT_MODAL_ID)
     .setTitle(`Edit Progression`);
+  addCommonProgressionModalFields(builder, progression);
   if (progression?.kind === 'milestone') {
-    builder.addLabelComponents(
-      new LabelBuilder().setLabel('sequential').setStringSelectMenuComponent(
-        new StringSelectMenuBuilder()
-          .setCustomId('progression-sequential')
-          .setPlaceholder('Is the progression sequential?')
-          .addOptions([
-            {
-              label: 'Yes',
-              value: 'yes',
-              default: progression.sequential === true,
-            },
-            {
-              label: 'No',
-              value: 'no',
-              default: progression.sequential === false,
-            },
-          ])
-          .setRequired(false)
-      )
-    );
+    addSequentialModalField(builder, progression);
   } else if (progression?.kind === 'numeric') {
-    builder.addLabelComponents(
-      new LabelBuilder()
-        .setLabel('min')
-        .setTextInputComponent(
-          setValueOnInputBuilderIfExists(
-            new TextInputBuilder()
-              .setCustomId('progression-min')
-              .setStyle(TextInputStyle.Short)
-              .setPlaceholder('Minimum value for the numeric progression')
-              .setRequired(false),
-            progression.min?.toString()
-          )
-        ),
-      new LabelBuilder()
-        .setLabel('max')
-        .setTextInputComponent(
-          setValueOnInputBuilderIfExists(
-            new TextInputBuilder()
-              .setCustomId('progression-max')
-              .setStyle(TextInputStyle.Short)
-              .setPlaceholder('Maximum value for the numeric progression')
-              .setRequired(false),
-            progression.max?.toString()
-          )
-        )
-    );
+    addMinMaxModalFields(builder, progression);
   }
+
   return {
     id: PROGRESSION_EDIT_MODAL_ID,
     builder,
@@ -144,7 +47,7 @@ const buildProgressionEditModal = (
       const region = await ctx.admin.getRegion(regionId);
       region.progressionDefinitions.set(
         progressionKey,
-        getupdatedProgression(progression, fields)
+        getUpdatedProgression(progression, fields)
       );
       await saveRegion(region);
       await ctx.hardRefresh();
@@ -152,36 +55,152 @@ const buildProgressionEditModal = (
   };
 };
 
-const getupdatedProgression = (
+// Adds the name, description, and visibility fields to the progression edit modal
+const addCommonProgressionModalFields = (
+  builder: ModalBuilder,
+  progression: Progression | undefined
+): void => {
+  builder.addLabelComponents(
+    new LabelBuilder()
+      .setLabel('name')
+      .setTextInputComponent(
+        setValueOnInputBuilderIfExists(
+          new TextInputBuilder()
+            .setCustomId('progression-name')
+            .setStyle(TextInputStyle.Short)
+            .setPlaceholder('e.g. Badges')
+            .setRequired(true),
+          progression?.name
+        )
+      ),
+    new LabelBuilder()
+      .setLabel('description')
+      .setTextInputComponent(
+        setValueOnInputBuilderIfExists(
+          new TextInputBuilder()
+            .setCustomId('progression-description')
+            .setStyle(TextInputStyle.Paragraph)
+            .setPlaceholder(
+              'e.g. The badges the player must collect in order to complete the region progression.'
+            )
+            .setRequired(false),
+          progression?.description
+        )
+      ),
+    new LabelBuilder().setLabel('visibility').setStringSelectMenuComponent(
+      new StringSelectMenuBuilder()
+        .setCustomId('progression-visibility')
+        .setPlaceholder('Select visibility')
+        .addOptions([
+          {
+            label: 'Public',
+            value: 'public',
+            default: progression?.visibility === 'public',
+          },
+          {
+            label: 'Discoverable',
+            value: 'discoverable',
+            default: progression?.visibility === 'discoverable',
+          },
+          {
+            label: 'Hidden',
+            value: 'hidden',
+            default: progression?.visibility === 'hidden',
+          },
+        ])
+        .setRequired(false)
+    )
+  );
+};
+
+const addSequentialModalField = (
+  builder: ModalBuilder,
+  progression: Progression | undefined
+): void => {
+  builder.addLabelComponents(
+    new LabelBuilder().setLabel('sequential').setStringSelectMenuComponent(
+      new StringSelectMenuBuilder()
+        .setCustomId('progression-sequential')
+        .setPlaceholder('Is the progression sequential?')
+        .addOptions([
+          {
+            label: 'Yes',
+            value: 'yes',
+            default:
+              progression?.kind === 'milestone' &&
+              progression.sequential === true,
+          },
+          {
+            label: 'No',
+            value: 'no',
+            default:
+              progression?.kind === 'milestone' &&
+              progression.sequential === false,
+          },
+        ])
+        .setRequired(false)
+    )
+  );
+};
+
+const addMinMaxModalFields = (
+  builder: ModalBuilder,
+  progression: Progression | undefined
+): void => {
+  builder.addLabelComponents(
+    new LabelBuilder()
+      .setLabel('min')
+      .setTextInputComponent(
+        setValueOnInputBuilderIfExists(
+          new TextInputBuilder()
+            .setCustomId('progression-min')
+            .setStyle(TextInputStyle.Short)
+            .setPlaceholder('Minimum value for the numeric progression')
+            .setRequired(false),
+          progression?.kind === 'numeric'
+            ? progression.min?.toString()
+            : undefined
+        )
+      ),
+    new LabelBuilder()
+      .setLabel('max')
+      .setTextInputComponent(
+        setValueOnInputBuilderIfExists(
+          new TextInputBuilder()
+            .setCustomId('progression-max')
+            .setStyle(TextInputStyle.Short)
+            .setPlaceholder('Maximum value for the numeric progression')
+            .setRequired(false),
+          progression?.kind === 'numeric'
+            ? progression.max?.toString()
+            : undefined
+        )
+      )
+  );
+};
+
+const getUpdatedProgression = (
   progression: Progression | undefined,
   fields: ModalSubmitFields<CacheType>
 ): Progression => {
-  let updatedProgression;
+  let updatedProgression = {
+    name: getModalTextValue(fields.fields, 'progression-name', true),
+    description: getModalTextValue(fields.fields, 'progression-description'),
+    kind: progression?.kind,
+    visibility: getModalSelectValue(fields.fields, 'progression-visibility'),
+  } as Progression;
   if (progression?.kind === 'milestone') {
     updatedProgression = {
-      name: getModalTextValue(fields.fields, 'progression-name', true),
-      description: getModalTextValue(fields.fields, 'progression-description'),
-      kind: progression.kind,
-      visibility: getModalSelectValue(fields.fields, 'progression-visibility'),
+      ...updatedProgression,
       sequential:
         getModalSelectValue(fields.fields, 'progression-sequential') === 'yes',
       milestones: progression.milestones,
     } as Progression;
   } else if (progression?.kind === 'numeric') {
     updatedProgression = {
-      name: getModalTextValue(fields.fields, 'progression-name', true),
-      description: getModalTextValue(fields.fields, 'progression-description'),
-      kind: progression.kind,
-      visibility: getModalSelectValue(fields.fields, 'progression-visibility'),
+      ...updatedProgression,
       min: getModalTextValue(fields.fields, 'progression-min'),
       max: getModalTextValue(fields.fields, 'progression-max'),
-    } as Progression;
-  } else {
-    updatedProgression = {
-      name: getModalTextValue(fields.fields, 'progression-name', true),
-      description: getModalTextValue(fields.fields, 'progression-description'),
-      kind: progression?.kind,
-      visibility: getModalSelectValue(fields.fields, 'progression-visibility'),
     } as Progression;
   }
   return updatedProgression;

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.ts
@@ -26,6 +26,10 @@ import {
   editProgressionFieldConfigMap,
   handleEditProgressionField,
 } from './utils';
+import {
+  getProgressionEditModal,
+  PROGRESSION_EDIT_MODAL_ID,
+} from './progressionEdit.modal';
 
 const COMMAND_NAME = 'progression-edit';
 export const PROGRESSION_EDIT_COMMAND_NAME = COMMAND_NAME;
@@ -120,6 +124,9 @@ export const ProgressionEditCommand: ISlashCommand = {
         });
       }
     }
+    builder.setModal((ctx) =>
+      getProgressionEditModal(ctx, region_id, progression_key)
+    );
 
     return builder.build();
   },
@@ -138,87 +145,23 @@ const getEditProgressionDefinitionButtons = async (
     AdminMenuContext<ProgressionEditMenuState>
   >[] = [
     {
-      id: 'name',
-      label: 'Name',
+      label: 'Edit',
       style: ButtonStyle.Primary,
-      action: async (ctx) => {
-        ctx.sessionState.set('progressionEditField', 'name');
-        await ctx.hardRefresh();
-      },
-    },
-    {
-      id: 'description',
-      label: 'Description',
-      style: ButtonStyle.Primary,
-      action: async (ctx) => {
-        ctx.sessionState.set('progressionEditField', 'description');
-        await ctx.hardRefresh();
-      },
-    },
-    {
-      id: 'visibility',
-      label: 'Visibility',
-      style: ButtonStyle.Primary,
-      action: async (ctx) => {
-        ctx.sessionState.set('progressionEditField', 'visibility');
-        await ctx.hardRefresh();
-      },
+      opensModal: PROGRESSION_EDIT_MODAL_ID,
     },
   ];
 
-  // Add kind-specific buttons
-  if (progression.kind === 'numeric') {
-    buttons.push(
-      {
-        id: 'min',
-        label: 'Min Value',
-        style: ButtonStyle.Primary,
-        action: async (ctx) => {
-          ctx.sessionState.set('progressionEditField', 'min');
-          await ctx.hardRefresh();
-        },
+  if (progression.kind === 'milestone') {
+    buttons.push({
+      label: 'Milestones',
+      style: ButtonStyle.Primary,
+      action: async (ctx) => {
+        await ctx.goTo(MILESTONES_COMMAND_NAME, {
+          region_id: regionId,
+          progression_key: progressionKey,
+        });
       },
-      {
-        id: 'max',
-        label: 'Max Value',
-        style: ButtonStyle.Primary,
-        action: async (ctx) => {
-          ctx.sessionState.set('progressionEditField', 'max');
-          await ctx.hardRefresh();
-        },
-      }
-    );
-  } else if (progression.kind === 'milestone') {
-    buttons.push(
-      {
-        label: 'Milestones',
-        style: ButtonStyle.Primary,
-        action: async (ctx) => {
-          await ctx.goTo(MILESTONES_COMMAND_NAME, {
-            region_id: regionId,
-            progression_key: progressionKey,
-          });
-        },
-      },
-      {
-        label: 'Toggle Sequential',
-        style: ButtonStyle.Primary,
-        action: async (ctx) => {
-          const region = await ctx.admin.getRegion(regionId);
-          if (progression.kind === 'milestone') {
-            progression.sequential = !progression.sequential;
-            region.progressionDefinitions.set(progressionKey, progression);
-            await saveRegion(region);
-            ctx.state.set(
-              'prompt',
-              `Sequential mode ${
-                progression.sequential ? 'enabled' : 'disabled'
-              }`
-            );
-          }
-        },
-      }
-    );
+    });
   }
 
   // Add delete button

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/progressionEdit.ts
@@ -18,14 +18,7 @@ import type { ButtonInputConfig } from '@flowcord/core';
 
 import { MILESTONES_COMMAND_NAME } from './milestones';
 import { progressionEditMenuEmbeds } from './progression.embeds';
-import type {
-  EditProgressionFieldConfig,
-  ProgressionEditMenuState,
-} from './types';
-import {
-  editProgressionFieldConfigMap,
-  handleEditProgressionField,
-} from './utils';
+import type { ProgressionEditMenuState } from './types';
 import {
   getProgressionEditModal,
   PROGRESSION_EDIT_MODAL_ID,
@@ -73,57 +66,21 @@ export const ProgressionEditCommand: ISlashCommand = {
     const progression = region.progressionDefinitions.get(progression_key);
     assert(progression, 'Progression definition not found');
 
-    const progressionEditField = session.sessionState.get(
-      'progressionEditField'
-    ) as string | undefined;
-    const config = editProgressionFieldConfigMap.get(
-      progressionEditField ?? ''
-    );
-
     const builder = new AdminMenuBuilder<ProgressionEditMenuState>(
       session,
       COMMAND_NAME,
       options
     )
       .setEmbeds((ctx) =>
-        progressionEditMenuEmbeds(
-          ctx,
-          region_id,
-          progression_key,
-          progressionEditField
-        )
+        progressionEditMenuEmbeds(ctx, region_id, progression_key)
       )
       .setCancellable()
       .setReturnable()
       .setTrackedInHistory();
 
-    if (!progressionEditField) {
-      builder.setButtons((ctx) =>
-        getEditProgressionDefinitionButtons(ctx, region_id, progression_key)
-      );
-    } else {
-      if (config?.getCustomButtons) {
-        builder.setButtons((ctx) =>
-          getProgressionEditFieldButtons(
-            ctx,
-            config,
-            region_id,
-            progression_key
-          )
-        );
-      }
-      if (config?.hasMessageHandler) {
-        builder.setMessageHandler(async (ctx, response) => {
-          await handleEditProgressionField(
-            ctx,
-            config,
-            region_id,
-            progression_key,
-            response
-          );
-        });
-      }
-    }
+    builder.setButtons((ctx) =>
+      getEditProgressionDefinitionButtons(ctx, region_id, progression_key)
+    );
     builder.setModal((ctx) =>
       getProgressionEditModal(ctx, region_id, progression_key)
     );
@@ -175,48 +132,6 @@ const getEditProgressionDefinitionButtons = async (
       await ctx.goBack();
     },
   });
-
-  return buttons;
-};
-
-const getProgressionEditFieldButtons = async (
-  ctx: AdminMenuContext<ProgressionEditMenuState>,
-  config: EditProgressionFieldConfig,
-  regionId: string,
-  progressionKey: string
-): Promise<ButtonInputConfig<AdminMenuContext<ProgressionEditMenuState>>[]> => {
-  const region = await ctx.admin.getRegion(regionId);
-  const progression = region.progressionDefinitions.get(progressionKey);
-  assert(progression, 'Progression definition not found');
-
-  const buttons: ButtonInputConfig<
-    AdminMenuContext<ProgressionEditMenuState>
-  >[] = [];
-
-  if (config.hasClearButton) {
-    buttons.push({
-      label: 'Clear',
-      style: ButtonStyle.Danger,
-      action: async (ctx) => {
-        await handleEditProgressionField(
-          ctx,
-          config,
-          regionId,
-          progressionKey,
-          ''
-        );
-      },
-    });
-  }
-  if (config.getCustomButtons) {
-    const customButtons = await config.getCustomButtons(
-      config,
-      region,
-      progressionKey,
-      progression
-    );
-    buttons.push(...customButtons);
-  }
 
   return buttons;
 };

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/types.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/types.ts
@@ -25,3 +25,33 @@ export type EditProgressionFieldConfig = {
     progression: ProgressionDefinition
   ) => Promise<ButtonInputConfig<AdminMenuContext<ProgressionEditMenuState>>[]>;
 };
+
+export type Progression =
+  | {
+      name: string;
+      description?: string;
+      kind: 'milestone';
+      visibility: 'public' | 'discoverable' | 'hidden';
+      sequential: boolean;
+      milestones: {
+        key: string;
+        label: string;
+        description?: string;
+        imageUrl?: string;
+        ordinal?: number;
+      }[];
+    }
+  | {
+      name: string;
+      description?: string;
+      kind: 'numeric';
+      visibility: 'public' | 'discoverable' | 'hidden';
+      min?: number;
+      max?: number;
+    }
+  | {
+      name: string;
+      description?: string;
+      kind: 'boolean';
+      visibility: 'public' | 'discoverable' | 'hidden';
+    };

--- a/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/types.ts
+++ b/apps/bot/src/interactions/guilds/1010726453974925402/slashCommands/regionManagement/progression/types.ts
@@ -25,33 +25,3 @@ export type EditProgressionFieldConfig = {
     progression: ProgressionDefinition
   ) => Promise<ButtonInputConfig<AdminMenuContext<ProgressionEditMenuState>>[]>;
 };
-
-export type Progression =
-  | {
-      name: string;
-      description?: string;
-      kind: 'milestone';
-      visibility: 'public' | 'discoverable' | 'hidden';
-      sequential: boolean;
-      milestones: {
-        key: string;
-        label: string;
-        description?: string;
-        imageUrl?: string;
-        ordinal?: number;
-      }[];
-    }
-  | {
-      name: string;
-      description?: string;
-      kind: 'numeric';
-      visibility: 'public' | 'discoverable' | 'hidden';
-      min?: number;
-      max?: number;
-    }
-  | {
-      name: string;
-      description?: string;
-      kind: 'boolean';
-      visibility: 'public' | 'discoverable' | 'hidden';
-    };


### PR DESCRIPTION
removed the name, description, visibility, sequential, min, and max buttons from the progression menu
added an edit button
which opens a modal that can change the values for the buttons removed
Closes #92